### PR TITLE
Update `root_path` since the definition of it does not accept params

### DIFF
--- a/lib/two_factor_authentication/controllers/helpers.rb
+++ b/lib/two_factor_authentication/controllers/helpers.rb
@@ -25,7 +25,7 @@ module TwoFactorAuthentication
             session["#{scope}_return_to"] = request.original_fullpath if request.get?
             redirect_to two_factor_authentication_path_for(scope)
           elsif request.format.json?
-            session["#{scope}_return_to"] = root_path(format: :html)
+            session["#{scope}_return_to"] = root_path
             render json: { redirect_to: two_factor_authentication_path_for(scope) }, status: :unauthorized
           end
         else


### PR DESCRIPTION
Since our definition of `root_path` does not accept params it would be best to remove using the `root_path` with params 